### PR TITLE
Replace unescaped apostrophes in resourceBundle with escaped ones

### DIFF
--- a/gatsby-theme-localization/src/gatsby/ssr/embedTranslations.tsx
+++ b/gatsby-theme-localization/src/gatsby/ssr/embedTranslations.tsx
@@ -95,7 +95,7 @@ export const onRenderBody = (
   });
 
   const Component = createPreloadNamespacesComponent({
-    resourceBundle: JSON.stringify(resourceBundle)
+    resourceBundle: JSON.stringify(resourceBundle).replace(/'/g, "\\'")
   });
 
   setHeadComponents(<Component key="resourceBundle" />);


### PR DESCRIPTION
Quick fix to avoid Syntax Error upon loading SSR pages, caused by unescaped apostrophes in the final localization bundle. #19 